### PR TITLE
Add a new struct as the return type for file system operations

### DIFF
--- a/fs_operations.go
+++ b/fs_operations.go
@@ -78,29 +78,29 @@ func listEntries(path string, depth float64, prefix string) OperationResult {
 	return OperationResult{Content: allEntries}
 }
 
-func readFile(path string) (string, error) {
+func readFile(path string) OperationResult {
 	info, err, exists := assertPath(path)
 	if err != nil {
-		return "", err
+		return OperationResult{Error: err}
 	}
 	if !exists {
-		return fmt.Sprintf("path not found at %s", path), nil
+		return OperationResult{Message: fmt.Sprintf("path not found at %s", path)}
 	}
 	if info.IsDir() {
-		return "path is a directory, must be a file", nil
+		return OperationResult{Message: "path is a directory, must be a file"}
 	}
 
 	content, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
-		return "", fmt.Errorf("error reading the file: %s", err)
+		return OperationResult{Error: fmt.Errorf("error reading the file: %s", err)}
 	}
 
 	// Check if content is valid UTF-8 text
 	if !utf8.Valid(content) {
-		return "file is not valid UTF-8 text (likely binary)", nil
+		return OperationResult{Message: "file is not valid UTF-8 text (likely binary)"}
 	}
 
-	return string(content), nil
+	return OperationResult{Content: string(content)}
 }
 
 func writeToFile(content, path string) (string, error) {

--- a/fs_operations.go
+++ b/fs_operations.go
@@ -180,14 +180,14 @@ func getMimeType(path string) (string, error) {
 	return mimeType, nil
 }
 
-func renamePath(path, newName string) (string, error) {
+func renamePath(path, newName string) OperationResult {
 	_, err, exists := assertPath(path)
 	if err != nil {
-		return "", err
+		return OperationResult{Error: err}
 	}
 
 	if !exists {
-		return fmt.Sprintf("path not found at %s", path), nil
+		return OperationResult{Message: fmt.Sprintf("path not found at %s", path)}
 	}
 
 	fileDir := filepath.Dir(path)
@@ -195,12 +195,15 @@ func renamePath(path, newName string) (string, error) {
 
 	// Check if new name already exists
 	if _, err := os.Stat(newPathName); err == nil {
-		return fmt.Sprintf("target path %s already exists", newPathName), nil
+		return OperationResult{Message: fmt.Sprintf("target path %s already exists", newPathName)}
 	}
 
-	os.Rename(path, newPathName)
+	err = os.Rename(path, newPathName)
+	if err != nil {
+		return OperationResult{Error: err}
+	}
 
-	return newPathName, nil
+	return OperationResult{Content: newPathName}
 }
 
 func copyFileOrDir(path, dst string) (string, error) {

--- a/fs_operations.go
+++ b/fs_operations.go
@@ -103,27 +103,27 @@ func readFile(path string) OperationResult {
 	return OperationResult{Content: string(content)}
 }
 
-func writeToFile(content, path string) (string, error) {
+func writeToFile(content, path string) OperationResult {
 	dir := filepath.Dir(path)
 
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		err = os.MkdirAll(dir, 0750)
 		if err != nil {
-			return "", fmt.Errorf("could not create directory: %s", err)
+			return OperationResult{Error: fmt.Errorf("could not create directory: %s", err)}
 		}
 	}
 
 	info, err := os.Stat(path)
 	if err == nil && info.IsDir() {
-		return "path is a directory, must be a file", nil
+		return OperationResult{Message: "path is a directory, must be a file"}
 	}
 
 	err = os.WriteFile(path, []byte(content), 0600)
 	if err != nil {
-		return "", fmt.Errorf("could not write to file: %s", err)
+		return OperationResult{Error: fmt.Errorf("could not write to file: %s", err)}
 	}
 
-	return "file written successfully", nil
+	return OperationResult{Content: "file written successfully"}
 }
 
 func getFileInfo(path string) (string, error) {

--- a/fs_operations.go
+++ b/fs_operations.go
@@ -126,21 +126,21 @@ func writeToFile(content, path string) OperationResult {
 	return OperationResult{Content: "file written successfully"}
 }
 
-func getFileInfo(path string) (string, error) {
+func getFileInfo(path string) OperationResult {
 	info, err, exists := assertPath(path)
 	if err != nil {
-		return "", err
+		return OperationResult{Error: err}
 	}
 	if !exists {
-		return fmt.Sprintf("path not found at %s", path), nil
+		return OperationResult{Message: fmt.Sprintf("path not found at %s", path)}
 	}
 	if info.IsDir() {
-		return "path is a directory, must be a file", nil
+		return OperationResult{Message: "path is a directory, must be a file"}
 	}
 
 	mimetype, err := getMimeType(path)
 	if err != nil {
-		return "", err
+		return OperationResult{Error: err}
 	}
 
 	perms := info.Mode().String()
@@ -159,7 +159,7 @@ func getFileInfo(path string) (string, error) {
 		mimetype,
 	)
 
-	return fileInfo, nil
+	return OperationResult{Content: fileInfo}
 }
 
 func getMimeType(path string) (string, error) {

--- a/fs_operations_test.go
+++ b/fs_operations_test.go
@@ -240,36 +240,43 @@ func TestReadFile(t *testing.T) {
 	os.MkdirAll(subDir, 0755)
 
 	tests := []struct {
-		name   string
-		path   string
-		expect string
+		name          string
+		path          string
+		expectMessage string
+		expectContent string
 	}{
 		{
-			name:   "read file sucessfully",
-			path:   filepath.Join(tmpDir, "file_1.txt"),
-			expect: "test",
+			name:          "read file sucessfully",
+			path:          filepath.Join(tmpDir, "file_1.txt"),
+			expectMessage: "",
+			expectContent: "test",
 		},
 		{
-			name:   "read file sucessfully",
-			path:   subDir,
-			expect: "path is a directory, must be a file",
+			name:          "read file sucessfully",
+			path:          subDir,
+			expectMessage: "path is a directory, must be a file",
+			expectContent: "",
 		},
 		{
-			name:   "read file sucessfully",
-			path:   "/not/exists/file.txt",
-			expect: "path not found at /not/exists/file.txt",
+			name:          "read file sucessfully",
+			path:          "/not/exists/file.txt",
+			expectMessage: "path not found at /not/exists/file.txt",
+			expectContent: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content, err := readFile(tt.path)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+			operationResult := readFile(tt.path)
+			if operationResult.Error != nil {
+				t.Errorf("unexpected error: %v", operationResult.Error)
 			}
 
-			if content != tt.expect {
-				t.Errorf("Got %s, expected: %s", content, tt.expect)
+			if operationResult.Message != tt.expectMessage {
+				t.Errorf("Got %s, expected: %s", operationResult.Message, tt.expectMessage)
+			}
+			if operationResult.Content != tt.expectContent {
+				t.Errorf("Got %s, expected: %s", operationResult.Content, tt.expectContent)
 			}
 		})
 	}

--- a/fs_operations_test.go
+++ b/fs_operations_test.go
@@ -375,46 +375,43 @@ func TestGetFileInfo(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		path     string
-		expect   string
-		contains bool
+		name          string
+		path          string
+		expectMessage string
+		expectContent string
 	}{
 		{
-			name:     "read file successfully",
-			path:     filePath,
-			expect:   "File: " + filePath,
-			contains: true,
+			name:          "read file successfully",
+			path:          filePath,
+			expectMessage: "",
+			expectContent: "File: " + filePath,
 		},
 		{
-			name:     "path is directory",
-			path:     subDir,
-			expect:   "path is a directory, must be a file",
-			contains: false,
+			name:          "path is directory",
+			path:          subDir,
+			expectMessage: "path is a directory, must be a file",
+			expectContent: "",
 		},
 		{
-			name:     "path does not exist",
-			path:     "/not/exists/file.txt",
-			expect:   "path not found at /not/exists/file.txt",
-			contains: false,
+			name:          "path does not exist",
+			path:          "/not/exists/file.txt",
+			expectMessage: "path not found at /not/exists/file.txt",
+			expectContent: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content, err := getFileInfo(tt.path)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+			operationResult := getFileInfo(tt.path)
+			if operationResult.Error != nil {
+				t.Errorf("unexpected error: %v", operationResult.Error)
 			}
 
-			if tt.contains {
-				if !strings.Contains(content, tt.expect) {
-					t.Errorf("Output does not contain expected substring.\nGot:\n%s\nExpected to contain:\n%s", content, tt.expect)
-				}
-			} else {
-				if content != tt.expect {
-					t.Errorf("Got:\n%s\nExpected:\n%s", content, tt.expect)
-				}
+			if operationResult.Message != tt.expectMessage {
+				t.Errorf("Got %s, expected: %s", operationResult.Message, tt.expectMessage)
+			}
+			if !strings.Contains(operationResult.Content, tt.expectContent) {
+				t.Errorf("Got %s, expected: %s", operationResult.Content, tt.expectContent)
 			}
 		})
 	}

--- a/fs_operations_test.go
+++ b/fs_operations_test.go
@@ -434,46 +434,54 @@ func TestRenameFilaAndDir(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		path        string
-		newPathName string
-		expect      string
+		name          string
+		path          string
+		newPathName   string
+		expectMessage string
+		expectContent string
 	}{
 		{
-			name:        "rename a file",
-			path:        filePathOne,
-			newPathName: "updated_file_name.txt",
-			expect:      filepath.Join(tmpDir, "updated_file_name.txt"),
+			name:          "rename a file",
+			path:          filePathOne,
+			newPathName:   "updated_file_name.txt",
+			expectMessage: "",
+			expectContent: filepath.Join(tmpDir, "updated_file_name.txt"),
 		},
 		{
-			name:        "rename a directory",
-			path:        subDir,
-			newPathName: "updated_dir_name",
-			expect:      filepath.Join(tmpDir, "updated_dir_name"),
+			name:          "rename a directory",
+			path:          subDir,
+			newPathName:   "updated_dir_name",
+			expectMessage: "",
+			expectContent: filepath.Join(tmpDir, "updated_dir_name"),
 		},
 		{
-			name:        "path does not exist",
-			path:        "/not/exists/file.txt",
-			newPathName: "updated_file_name.txt",
-			expect:      "path not found at /not/exists/file.txt",
+			name:          "path does not exist",
+			path:          "/not/exists/file.txt",
+			newPathName:   "updated_file_name.txt",
+			expectMessage: "path not found at /not/exists/file.txt",
+			expectContent: "",
 		},
 		{
-			name:        "file already exists",
-			path:        filePathTwo,
-			newPathName: "updated_file_name.txt",
-			expect:      fmt.Sprintf("target path %s already exists", filepath.Join(tmpDir, "updated_file_name.txt")),
+			name:          "file already exists",
+			path:          filePathTwo,
+			newPathName:   "updated_file_name.txt",
+			expectMessage: fmt.Sprintf("target path %s already exists", filepath.Join(tmpDir, "updated_file_name.txt")),
+			expectContent: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content, err := renamePath(tt.path, tt.newPathName)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+			operationResult := renamePath(tt.path, tt.newPathName)
+			if operationResult.Error != nil {
+				t.Errorf("unexpected error: %v", operationResult.Error)
 			}
 
-			if content != tt.expect {
-				t.Errorf("Got:\n%s\nExpected:\n%s", content, tt.expect)
+			if operationResult.Message != tt.expectMessage {
+				t.Errorf("Got %s, expected: %s", operationResult.Message, tt.expectMessage)
+			}
+			if operationResult.Content != tt.expectContent {
+				t.Errorf("Got %s, expected: %s", operationResult.Content, tt.expectContent)
 			}
 		})
 	}

--- a/fs_operations_test.go
+++ b/fs_operations_test.go
@@ -182,43 +182,51 @@ func TestListEntries(t *testing.T) {
 	)
 
 	tests := []struct {
-		name   string
-		path   string
-		expect string
-		err    error
+		name          string
+		path          string
+		expectContent string
+		expectMessage string
+		err           error
 	}{
 		{
-			name:   "esisting entries and subentries",
-			path:   tmpDir,
-			expect: expectedSuccess,
-			err:    errors.New(""),
+			name:          "esisting entries and subentries",
+			path:          tmpDir,
+			expectContent: expectedSuccess,
+			expectMessage: "",
+			err:           errors.New(""),
 		},
 		{
-			name:   "passing a file path",
-			path:   "/not/exists/dir",
-			expect: "path not found at /not/exists/dir",
-			err:    errors.New(""),
+			name:          "passing a file path",
+			path:          "/not/exists/dir",
+			expectContent: "",
+			expectMessage: "path not found at /not/exists/dir",
+			err:           errors.New(""),
 		},
 		{
-			name:   "directorie do not exists",
-			path:   filepath.Join(tmpDir, "file_1.txt"),
-			expect: "path is not a directory",
-			err:    errors.New(""),
+			name:          "directorie do not exists",
+			path:          filepath.Join(tmpDir, "file_1.txt"),
+			expectContent: "",
+			expectMessage: "path is not a directory",
+			err:           errors.New(""),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			entries, err := listEntries(tt.path, 3, "")
+			operationResult := listEntries(tt.path, 3, "")
 
-			if err != nil {
-				if tt.err != errors.New("") && err != tt.err {
-					t.Errorf("got unexpected error %v", err)
+			if operationResult.Error != nil {
+				if tt.err != errors.New("") && operationResult.Error != tt.err {
+					t.Errorf("got unexpected error %v", operationResult.Error)
 				}
 			}
 
-			if entries != tt.expect {
-				t.Errorf("Expected:\n %v\nGot:\n%q", tt.expect, entries)
+			if operationResult.Content != tt.expectContent {
+				t.Errorf("Expected:\n %v\nGot:\n%q", tt.expectContent, operationResult.Content)
+			}
+
+			if operationResult.Message != tt.expectMessage {
+				t.Errorf("Expected:\n %v\nGot:\n%q", tt.expectMessage, operationResult.Message)
 			}
 		})
 	}

--- a/fs_operations_test.go
+++ b/fs_operations_test.go
@@ -506,40 +506,47 @@ func TestCopyFileOrDir(t *testing.T) {
 	copyDestinationDirPath := filepath.Join(tmpDir, "folder_copy")
 
 	tests := []struct {
-		name        string
-		source      string
-		destination string
-		expect      string
+		name          string
+		source        string
+		destination   string
+		expectMessage string
+		expectContent string
 	}{
 		{
-			name:        "copy file",
-			source:      filePath,
-			destination: destinationFilePath,
-			expect:      "File copied to destination",
+			name:          "copy file",
+			source:        filePath,
+			destination:   destinationFilePath,
+			expectMessage: "",
+			expectContent: "File copied to destination",
 		},
 		{
-			name:        "copy directory",
-			source:      folderPath,
-			destination: copyDestinationDirPath,
-			expect:      "",
+			name:          "copy directory",
+			source:        folderPath,
+			destination:   copyDestinationDirPath,
+			expectMessage: "",
+			expectContent: "",
 		},
 		{
-			name:        "copy non-existent file",
-			source:      filepath.Join(tmpDir, "nonexistent.txt"),
-			destination: filepath.Join(tmpDir, "nonexistent_copy.txt"),
-			expect:      "path not found at " + filepath.Join(tmpDir, "nonexistent.txt"),
+			name:          "copy non-existent file",
+			source:        filepath.Join(tmpDir, "nonexistent.txt"),
+			destination:   filepath.Join(tmpDir, "nonexistent_copy.txt"),
+			expectMessage: "path not found at " + filepath.Join(tmpDir, "nonexistent.txt"),
+			expectContent: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := copyFileOrDir(tt.source, tt.destination)
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+			operationResult := copyFileOrDir(tt.source, tt.destination)
+			if operationResult.Error != nil {
+				t.Errorf("unexpected error: %v", operationResult.Error)
 			}
 
-			if result != tt.expect {
-				t.Errorf("Got: %v, Expected: %v", result, tt.expect)
+			if operationResult.Message != tt.expectMessage {
+				t.Errorf("Got %s, expected: %s", operationResult.Message, tt.expectMessage)
+			}
+			if operationResult.Content != tt.expectContent {
+				t.Errorf("Got %s, expected: %s", operationResult.Content, tt.expectContent)
 			}
 		})
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -72,14 +72,20 @@ func (s *handler) handlerWriteToFile(
 ) (*mcp.CallToolResult, error) {
 	content := request.Params.Arguments["content"].(string)
 
-	msg, err := writeToFile(content, path)
-	if err != nil {
-		log.Printf("ERROR: %v\n", err)
-		return mcp.NewToolResultErrorFromErr("", err), err
+	operationResult := writeToFile(content, path)
+	if operationResult.Error != nil {
+		log.Printf("ERROR: %v\n", operationResult.Error)
+		return mcp.NewToolResultErrorFromErr("", operationResult.Error), operationResult.Error
 	}
+
+	if operationResult.Message != "" {
+		log.Printf("WARNING: %v\n", operationResult.Message)
+		return mcp.NewToolResultText(operationResult.Message), nil
+	}
+
 	log.Printf("File sucessfully written at: %v\n", path)
 
-	return mcp.NewToolResultText(msg), nil
+	return mcp.NewToolResultText(operationResult.Content), nil
 }
 
 func (s *handler) handlerGetFileInfo(

--- a/handlers.go
+++ b/handlers.go
@@ -51,14 +51,20 @@ func (s *handler) handlerListEntries(
 func (s *handler) handlerReadFile(
 	ctx context.Context, path string, request mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
-	entries, err := readFile(path)
-	if err != nil {
-		log.Printf("ERROR: %v\n", err)
-		return mcp.NewToolResultErrorFromErr("", err), err
+	operationResult := readFile(path)
+	if operationResult.Error != nil {
+		log.Printf("ERROR: %v\n", operationResult.Error)
+		return mcp.NewToolResultErrorFromErr("", operationResult.Error), operationResult.Error
 	}
+
+	if operationResult.Message != "" {
+		log.Printf("WARNING: %v\n", operationResult.Message)
+		return mcp.NewToolResultText(operationResult.Message), nil
+	}
+
 	log.Printf("File sucessfully read from: %v\n", path)
 
-	return mcp.NewToolResultText(entries), nil
+	return mcp.NewToolResultText(operationResult.Content), nil
 }
 
 func (s *handler) handlerWriteToFile(

--- a/handlers.go
+++ b/handlers.go
@@ -91,14 +91,20 @@ func (s *handler) handlerWriteToFile(
 func (s *handler) handlerGetFileInfo(
 	ctx context.Context, path string, request mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
-	msg, err := getFileInfo(path)
-	if err != nil {
-		log.Printf("ERROR: %v\n", err)
-		return mcp.NewToolResultErrorFromErr("", err), err
+	operationResult := getFileInfo(path)
+	if operationResult.Error != nil {
+		log.Printf("ERROR: %v\n", operationResult.Error)
+		return mcp.NewToolResultErrorFromErr("", operationResult.Error), operationResult.Error
 	}
+
+	if operationResult.Message != "" {
+		log.Printf("WARNING: %v\n", operationResult.Message)
+		return mcp.NewToolResultText(operationResult.Message), nil
+	}
+
 	log.Printf("Returning files info from file at: %v\n", path)
 
-	return mcp.NewToolResultText(msg), nil
+	return mcp.NewToolResultText(operationResult.Content), nil
 }
 
 func (s *handler) hadlerRenamePath(

--- a/handlers.go
+++ b/handlers.go
@@ -138,14 +138,19 @@ func (s *handler) hadlerCopyFileOrDir(
 		return mcp.NewToolResultText("access denied: path is outside of allowed base directory"), nil
 	}
 
-	msg, err := copyFileOrDir(path, destination)
-	if err != nil {
-		log.Printf("ERROR: %v\n", err)
-		return mcp.NewToolResultErrorFromErr("", err), err
+	operationResult := copyFileOrDir(path, destination)
+	if operationResult.Error != nil {
+		log.Printf("ERROR: %v\n", operationResult.Error)
+		return mcp.NewToolResultErrorFromErr("", operationResult.Error), operationResult.Error
+	}
+
+	if operationResult.Message != "" {
+		log.Printf("WARNING: %v\n", operationResult.Message)
+		return mcp.NewToolResultText(operationResult.Message), nil
 	}
 	log.Printf("Returning files info from file at: %v\n", path)
 
-	return mcp.NewToolResultText(msg), nil
+	return mcp.NewToolResultText(operationResult.Content), nil
 }
 
 func handlersMiddleware(name string, fn server.ToolHandlerFunc) server.ToolHandlerFunc {

--- a/handlers.go
+++ b/handlers.go
@@ -34,13 +34,18 @@ func (s *handler) handlerListEntries(
 		depth = d.(float64)
 	}
 
-	entries, err := listEntries(path, depth, "")
-	if err != nil {
-		log.Printf("ERROR: %v\n", err)
-		return mcp.NewToolResultErrorFromErr("", err), err
+	operationResult := listEntries(path, depth, "")
+	if operationResult.Error != nil {
+		log.Printf("ERROR: %v\n", operationResult.Error)
+		return mcp.NewToolResultErrorFromErr("", operationResult.Error), operationResult.Error
 	}
 
-	return mcp.NewToolResultText(entries), nil
+	if operationResult.Message != "" {
+		log.Printf("WARNING: %v\n", operationResult.Message)
+		return mcp.NewToolResultText(operationResult.Message), nil
+	}
+
+	return mcp.NewToolResultText(operationResult.Content), nil
 }
 
 func (s *handler) handlerReadFile(

--- a/handlers.go
+++ b/handlers.go
@@ -112,14 +112,20 @@ func (s *handler) hadlerRenamePath(
 ) (*mcp.CallToolResult, error) {
 	newPathFinalName := request.Params.Arguments["newPathFinalName"].(string)
 
-	msg, err := renamePath(path, newPathFinalName)
-	if err != nil {
-		log.Printf("ERROR: %v\n", err)
-		return mcp.NewToolResultErrorFromErr("", err), err
+	operationResult := renamePath(path, newPathFinalName)
+	if operationResult.Error != nil {
+		log.Printf("ERROR: %v\n", operationResult.Error)
+		return mcp.NewToolResultErrorFromErr("", operationResult.Error), operationResult.Error
 	}
+
+	if operationResult.Message != "" {
+		log.Printf("WARNING: %v\n", operationResult.Message)
+		return mcp.NewToolResultText(operationResult.Message), nil
+	}
+
 	log.Printf("Returning files info from file at: %v\n", path)
 
-	return mcp.NewToolResultText(msg), nil
+	return mcp.NewToolResultText(operationResult.Content), nil
 }
 
 func (s *handler) hadlerCopyFileOrDir(


### PR DESCRIPTION
This PR introduces a new struct, `OperationResult`, as the return type for the core filesystem functions in `fs_operation.go`.

This enables separating warning messages from the actual content, improving clarity in output handling.